### PR TITLE
Update hiera configuration to correlate with updated site configuration parameters

### DIFF
--- a/Dockerfile.em
+++ b/Dockerfile.em
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get dist-upgrade -y
 RUN apt-get update && apt-get install -y git wget openjdk-7-jdk ca-certificates
 # installing here to leverage docker caching (will be enforced by puppet later)
 RUN apt-get update && apt-get install -y curl python3-yaml python3-empy apt-transport-https bzr mercurial
-RUN apt-get update && apt-get install -y apparmor cgroup-lite ntp
+RUN apt-get update && apt-get install -y apparmor cgroup-lite ntp openssh-server python-yaml python-configparser
 
 # Docker specific changes.
 

--- a/Dockerfile.em
+++ b/Dockerfile.em
@@ -4,10 +4,10 @@ MAINTAINER "Tully Foote" <tfoote@@osrfoundation.org>
 RUN apt-get update && apt-get dist-upgrade -y
 
 # Prerequisites implicitly installed, but explicit allows docker caching
-RUN apt-get install -y git wget openjdk-7-jdk ca-certificates
+RUN apt-get update && apt-get install -y git wget openjdk-7-jdk ca-certificates
 # installing here to leverage docker caching (will be enforced by puppet later)
-RUN apt-get install -y curl python3-yaml python3-empy apt-transport-https bzr mercurial
-RUN apt-get install -y apparmor cgroup-lite ntp
+RUN apt-get update && apt-get install -y curl python3-yaml python3-empy apt-transport-https bzr mercurial
+RUN apt-get update && apt-get install -y apparmor cgroup-lite ntp
 
 # Docker specific changes.
 

--- a/master/common.yaml
+++ b/master/common.yaml
@@ -16,8 +16,16 @@ credentials::jenkins-slave::passphrase: 4lRsx/NwfEndwUlcWOOnYg==
 
 jenkins::nodeMonitor::minimum_disk_space: 5G
 
-jenkins::authorized_keys: |
-    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd tfoote@yeti
+ssh_keys:
+    'tfoote@zug':
+        key: AAAAB3NzaC1yc2EAAAABIwAAAQEApDU8Bxx4a51OnPms2Kuw/9K6RA+Mjp1lGAn8GpKs1Mr2SOZattPd085v4dgc+Ydnud57Pk+FkuyOWvmd07AjQ+h2+OH9pE+pMVVWXddz36svQeVb0/yvgbCiMxPqQi//ctQmJmPEAuF6gs4imMSHTtmLdWYzqVGkJ4TZwpyERC/c7TyfVZ7zvkNZ2+3pcceiS5F86M/CNgRBvdLQ9jk6x3S93JR0V49xkxRUE428qFzuRggv8m//5hrgXCyty/ZUQlTI5CcwKsedQLcPtOjTTakCw9o7x0ShXYWKD7MelYkUPKbE0H4J87AVm9H9SGs02WsuAbOL7NacboMGCxIcsw==
+        type: ssh-rsa
+        user: root
+    'tfoote@yeti':
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd
+        type: ssh-rsa
+        user: jenkins-slave
+        require: User[jenkins-slave]
 
 jenkins::private_ssh_key: |
     -----BEGIN RSA PRIVATE KEY-----

--- a/repo/common.yaml
+++ b/repo/common.yaml
@@ -268,6 +268,16 @@ jenkins-slave::reprepro_config:
             component: main
             architectures: [i386, amd64, source]
             filter_formula: Package (% *collada-dom* )
+    '/home/jenkins-slave/reprepro_config/libopenni.yaml':
+        ensure: 'present'
+        content: |
+            name: libopenni
+            method: http://ppa.launchpad.net/v-launchpad-jochen-sprickerhof-de/pcl/ubuntu
+            # Import libopenni from pcl ppa for saucy. It's upstream in trusty and higher.
+            suites: [saucy]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% libopenni* ) | Package (== openni-utils)
 
 
 

--- a/repo/common.yaml
+++ b/repo/common.yaml
@@ -94,8 +94,18 @@ jenkins-slave::gpg_public_key: |
     xaePFwP+okKW1h9qvwFhNF0JSCtdJrexdCf8jGE7
     =E8ot
     -----END PGP PUBLIC KEY BLOCK-----
-jenkins-slave::authorized_keys: |
-    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd tfoote@yeti
+
+ssh_keys:
+    'tfoote@zug':
+        key: AAAAB3NzaC1yc2EAAAABIwAAAQEApDU8Bxx4a51OnPms2Kuw/9K6RA+Mjp1lGAn8GpKs1Mr2SOZattPd085v4dgc+Ydnud57Pk+FkuyOWvmd07AjQ+h2+OH9pE+pMVVWXddz36svQeVb0/yvgbCiMxPqQi//ctQmJmPEAuF6gs4imMSHTtmLdWYzqVGkJ4TZwpyERC/c7TyfVZ7zvkNZ2+3pcceiS5F86M/CNgRBvdLQ9jk6x3S93JR0V49xkxRUE428qFzuRggv8m//5hrgXCyty/ZUQlTI5CcwKsedQLcPtOjTTakCw9o7x0ShXYWKD7MelYkUPKbE0H4J87AVm9H9SGs02WsuAbOL7NacboMGCxIcsw==
+        type: ssh-rsa
+        user: root
+    'tfoote@yeti':
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd
+        type: ssh-rsa
+        user: jenkins-slave
+        require: User[jenkins-slave]
+
 
 jenkins-slave::reprepro_updater_config: |
     [ubuntu_building]

--- a/repo/common.yaml
+++ b/repo/common.yaml
@@ -103,21 +103,162 @@ jenkins-slave::reprepro_updater_config: |
     distros: lucid maverick natty oneiric precise quantal raring saucy trusty utopic vivid
     repository_path: /var/repos/ubuntu/building
     signing_key: E5944336
-    upstream_config: /home/jenkins-slave/reprepro-updater/config
+    upstream_config: /home/jenkins-slave/reprepro_config
 
     [ubuntu_testing]
     architectures: amd64 armhf i386 source
     distros: lucid maverick natty oneiric precise quantal raring saucy trusty utopic vivid
     repository_path: /var/repos/ubuntu/testing
     signing_key: E5944336
-    upstream_config: /home/jenkins-slave/reprepro-updater/config
+    upstream_config: /home/jenkins-slave/reprepro_config
 
     [ubuntu_main]
     architectures: amd64 armhf i386 source
     distros: lucid maverick natty oneiric precise quantal raring saucy trusty utopic vivid
     repository_path: /var/repos/ubuntu/main
     signing_key: E5944336
-    upstream_config: /home/jenkins-slave/reprepro-updater/config
+    upstream_config: /home/jenkins-slave/reprepro_config
+
+jenkins-slave::reprepro_config:
+    '/home/jenkins-slave/reprepro_config/ros_public_bootstrap.yaml':
+        ensure: 'present'
+        content: |
+            name: ros_public_bootstrap
+            method: http://repos.ros.org/repos/ros/ubuntu
+            suites: [lucid, maverick, natty, oneiric, precise, quantal, raring, saucy, trusty, utopic, vivid]
+            component: main
+            architectures: [i386, amd64, armel, armhf, source]
+            filter_formula: Package (% python* )
+            # needed until we deploy the gpg key
+            verify_release: blindtrust
+    '/home/jenkins-slave/reprepro_config/empy_saucy.yaml':
+        ensure: 'present'
+        content: |
+            name: empy_saucy
+            method: http://packages.osrfoundation.org/gazebo/ubuntu
+            suites: [saucy]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% python3-empy)
+    '/home/jenkins-slave/reprepro_config/empy_trusty.yaml':
+        ensure: 'present'
+        content: |
+            name: empy_trusty
+            method: http://packages.osrfoundation.org/gazebo/ubuntu
+            suites: [trusty]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% python-empy ) | Package (% python3-empy)
+    '/home/jenkins-slave/reprepro_config/bullet_precise.yaml':
+        ensure: 'present'
+        content: |
+            name: bulletppa
+            method: http://ppa.launchpad.net/blk/ppa/ubuntu/
+            suites: [precise]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% *libbullet* )
+    '/home/jenkins-slave/reprepro_config/namniart_armhf_trusty.yaml':
+        ensure: 'present'
+        content: |
+            name: namniart_armhf_bootstrap
+            # method: http://packages.namniart.com/repos/ros_support/
+            method: http://23.239.1.142/repos/ros_support/
+            suites: [trusty]
+            component: main
+            architectures: [armhf]
+            filter_formula: '(Package (% * ), !Package (% openni2-doc*), !Package(% libpcl-1.7-all*), !Package(% libpcl-1.7-doc*))'
+            # needed until we deploy the gpg key
+            verify_release: blindtrust
+    '/home/jenkins-slave/reprepro_config/ceres.yaml':
+        ensure: 'present'
+        content: |
+            name: ceres
+            method: http://ppa.launchpad.net/mikeferguson/ceres-solver/ubuntu
+            suites: [trusty, utopic, vivid]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (== ceres-solver ) | Package (% libceres ) | Package (% libceres-dev )
+    '/home/jenkins-slave/reprepro_config/catkinlint.yaml':
+        ensure: 'present'
+        content: |
+            name: catkinlint
+            method: http://ppa.launchpad.net/roehling/latest/ubuntu
+            suites: [precise, quantal, raring, saucy, trusty, utopic, vivid]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (== catkin-lint ) | Package (== python-catkin-lint)
+    '/home/jenkins-slave/reprepro_config/catkinlint.yaml':
+        ensure: 'present'
+        content: |
+            name: urdfdom_import
+            method: http://packages.osrfoundation.org/gazebo/ubuntu
+            suites: [saucy]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% libconsole-bridge* ) | Package (% liburdfdom* ) | Package (== urdfdom) | Package (== console-bridge)
+    '/home/jenkins-slave/reprepro_config/urdfdom.yaml':
+        ensure: 'present'
+        content: |
+            name: urdfdom_import
+            method: http://packages.osrfoundation.org/gazebo/ubuntu
+            suites: [saucy]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% libconsole-bridge* ) | Package (% liburdfdom* ) | Package (== urdfdom) | Package (== console-bridge)
+    '/home/jenkins-slave/reprepro_config/qtsixa.yaml':
+        ensure: 'present'
+        content: |
+            name: qtsixa
+            method: http://ppa.launchpad.net/falk-t-j/qtsixa/ubuntu
+            # For now only import saucy, trusty. PQR have patched versions for openni compatibility
+            # suites: [lucid, maverick, natty, oneiric, precise, quantal, raring, saucy, trusty]
+            suites: [saucy, trusty]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (== qtsixa ) | Package (== sixad)
+    '/home/jenkins-slave/reprepro_config/pcl.yaml':
+        ensure: 'present'
+        content: |
+            name: pclppa
+            method: http://ppa.launchpad.net/v-launchpad-jochen-sprickerhof-de/pcl/ubuntu
+            # For now only import saucy, trusty. PQR have patched versions for openni compatibility
+            # suites: [lucid, maverick, natty, oneiric, precise, quantal, raring, saucy, trusty]
+            suites: [saucy, trusty]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% *openni2* ) | Package (% *pcl*-1.7* )
+    '/home/jenkins-slave/reprepro_config/gazebo2.yaml':
+        ensure: 'present'
+        content: |
+            name: gazebo2_import
+            method: http://packages.osrfoundation.org/gazebo/ubuntu
+            suites: [saucy, trusty]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% gazebo2-dbg ) | Package (% gazebo2 ) | Package (% libsdformat1) | Package (% libsdformat1-dbg) | Package (% libsdformat-dev) | Package (% libtar* )
+    '/home/jenkins-slave/reprepro_config/gazebo.yaml':
+        ensure: 'present'
+        content: |
+            name: gazebo
+            method: http://packages.osrfoundation.org/gazebo/ubuntu
+            suites: [precise, quantal, raring, saucy]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% gazebo-dbg ) | Package (% gazebo ) | Package (% sdformat)
+    '/home/jenkins-slave/reprepro_config/colladadom.yaml':
+        ensure: 'present'
+        content: |
+            name: colladadomppa
+            #Switching to testing for newer colladadom
+            #method: http://ppa.launchpad.net/openrave/release/ubuntu
+            #suites: [lucid, maverick, natty, oneiric, precise, quantal, raring, saucy, trusty]
+            method: http://ppa.launchpad.net/openrave/testing/ubuntu
+            suites: [saucy, trusty]
+            component: main
+            architectures: [i386, amd64, source]
+            filter_formula: Package (% *collada-dom* )
+
 
 
 

--- a/slave/common.yaml
+++ b/slave/common.yaml
@@ -6,6 +6,12 @@ jenkins::slave::num_executors: 1
 # master::ip: 54.67.30.249
 # repo::ip: 54.67.51.1
 
+ssh_keys:
+    'tfoote@zug':
+        key: AAAAB3NzaC1yc2EAAAABIwAAAQEApDU8Bxx4a51OnPms2Kuw/9K6RA+Mjp1lGAn8GpKs1Mr2SOZattPd085v4dgc+Ydnud57Pk+FkuyOWvmd07AjQ+h2+OH9pE+pMVVWXddz36svQeVb0/yvgbCiMxPqQi//ctQmJmPEAuF6gs4imMSHTtmLdWYzqVGkJ4TZwpyERC/c7TyfVZ7zvkNZ2+3pcceiS5F86M/CNgRBvdLQ9jk6x3S93JR0V49xkxRUE428qFzuRggv8m//5hrgXCyty/ZUQlTI5CcwKsedQLcPtOjTTakCw9o7x0ShXYWKD7MelYkUPKbE0H4J87AVm9H9SGs02WsuAbOL7NacboMGCxIcsw==
+        type: ssh-rsa
+        user: root
+
 autoreconfigure: true
 autoreconfigure::command: 'bash -c "cd /root/buildfarm_deployment_config && git fetch origin master && git reset --hard origin/master && ./reconfigure.bash slave"'
 

--- a/slave/common.yaml
+++ b/slave/common.yaml
@@ -1,7 +1,7 @@
 jenkins::slave::ui_user: 'admin'
 jenkins::slave::ui_pass: 'changeme'
 jenkins::slave::masterurl: 'http://master:8080'
-jenkins::slave::num_executors: 1
+jenkins::slave::num_executors: 2
 
 # master::ip: 54.67.30.249
 # repo::ip: 54.67.51.1
@@ -15,4 +15,4 @@ ssh_keys:
 autoreconfigure: true
 autoreconfigure::command: 'bash -c "cd /root/buildfarm_deployment_config && git fetch origin master && git reset --hard origin/master && ./reconfigure.bash slave"'
 
-run_squid: true
+run_squid: false


### PR DESCRIPTION
This needs to be merged in conjunction with: https://github.com/ros-infrastructure/buildfarm_deployment/pull/38

There are some optimizations for testing, but the main thing is that ssh_authorized_keys are deployed via the hiera key `ssh_keys` and the reprepro-updater configuration is now in the hiera key `jenkins-slave::reprepro_config`
