### PR TITLE
Deprecate trusty branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # buildfarm_deployment_config
 
+***Deprecation notice***
+
+This branch supports deployment to Ubuntu 14.04 (Trusty) hosts.
+The canonical buildfarm: [build.ros.org](https://build.ros.org) has migrated to Ubuntu 16.04 (Xenial) with a substantial refactoring of the puppet scripts.
+
+This Trusty branch will no longer receive improvements or bug fixes from Open Robotics but you're welcome to keep using it until you have the opportunity to migrate to Xenial.
+
+---
+
 This is the repository with the example configurations for the [buildfarm_deployment](https://github.com/ros-infrastructure/buildfarm_deployment) implementation.
 Please see the documentation in that repository for how to setup a buildfarm.
 


### PR DESCRIPTION
Analogous to https://github.com/ros-infrastructure/buildfarm_deployment/pull/157

Adds the same deprecation notice to this branch.

Since most folks have forked the configuration I don't think there's much benefit in changing any values as part of this PR. If we did it would likely be just the autoreconfigure_command key.