### PR TITLE
Don't pin to a specific Jenkins version.

### DIFF
--- a/hiera/hieradata/buildfarm_role/master.yaml
+++ b/hiera/hieradata/buildfarm_role/master.yaml
@@ -15,8 +15,14 @@ jenkins_java_args: '-XX:MaxPermSize=512m -Xmx20g'
 jenkins::nodeMonitor::minimum_disk_space: 50G
 
 # Jenkins component module parameters.
+# The Jenkins team recommends that production deployments use the latest LTS version of Jenkins.
 jenkins::lts: true
-jenkins::version: '2.60.3'
+# Depending on your needs, you may wish to pin to a specific Jenkins release.
+# In light of https://github.com/ros-infrastructure/buildfarm_deployment/issues/160 it is
+# unlikely that puppet will be run multiple times on a master host, but if you do re-run puppet
+# on master omitting an explicit version may cause Jenkins to update before you have a chance
+# to review the changelog.
+#jenkins::version: '2.89.2'
 jenkins::slave::executors: 1
 jenkins::slave::install_java: false
 jenkins::slave::labels: agent_on_master


### PR DESCRIPTION
Inspired by https://answers.ros.org/question/279573/what-is-the-update-policy-on-jenkins-plugins-for-the-buildfarm/
This removes a hard-coded Jenkins version in favor of just using the lts => true key to grab the latest LTS.

Implications of this change are documented as a comment paragraph above the key.

Hat-tip to @gavanderhoorn for prompting the discussion.