### PR TITLE
Docker module does not need to install additional kernel packages.

### DIFF
--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -27,6 +27,14 @@ autoreconfigure: false
 # Pay special attention to the Git branch name that appears twice in the invocation below.
 autoreconfigure::command: 'bash -c "cd /root/buildfarm_deployment_config && git fetch origin xenialize && git reset --hard origin/xenialize && ./reconfigure.bash"'
 
+# This docker option is being removed from the upstream puppetlabs-docker module.
+# It isn't required on Ubuntu Xenial and causes an error when deploying to AWS with the default AWS kernel.
+#
+# By the time our project is able to move to the new puppet module (requires puppet >= 4.0) this option will probably
+# be removed.
+# https://github.com/puppetlabs/puppetlabs-docker/issues/38
+docker::manage_kernel: false
+
 # Classes to be pulled in via hiera_include classes.
 #classes:
     # Enables the New Relic sysmon daemon.


### PR DESCRIPTION
Since the deployment of the new AWS-optimised kernel for Ubuntu in April
2017, buildfarm deployments on AWS will fail unless the operator first
reverts to the default virtual kernel.

The "manage_kernel" parameter is meant to install supplementary kernel
packages required by older combinations of docker and Ubuntu.
https://github.com/garethr/garethr-docker/blob/ccade80caf3be669241e733d6489828789cba5c1/manifests/install.pp#L65-L67

According to the official puppet-docker module, which was copied from
garethr/docker without commit history, this flag is no longer needed any
of their supported platforms <sup>[1]</sup> and is due to be removed.

Since Ubuntu Xenial is one of the platforms that this is no longer
needed on. Removing it to allow the use of the AWS-optimized kernel does
no harm.

[1]: https://github.com/puppetlabs/puppetlabs-docker/issues/38