### PR TITLE
Add 'timezone' hiera key to common.yaml

### DIFF
--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -11,6 +11,9 @@ jenkins::slave::masterurl: 'http://master:8080'
 master::ip: 172.30.1.145
 repo::ip: 172.30.1.69
 
+# change this to match the timezone that this buildfarm is located in.
+timezone: 'America/Los_Angeles'
+
 # SSH keys to be added to the system.
 # The example public key should be changed but the private key has been deliberately deleted rather than leaked.
 ssh_keys:


### PR DESCRIPTION
As the documentation is currently not up-to-date wrt hiera files, adding the `timezone` key here gives it a bit better visibility.
