### PR TITLE
Stick with jenkins 2.89.4 pending JEP-200 testing.

### DIFF
--- a/hiera/hieradata/buildfarm_role/master.yaml
+++ b/hiera/hieradata/buildfarm_role/master.yaml
@@ -22,7 +22,7 @@ jenkins::lts: true
 # unlikely that puppet will be run multiple times on a master host, but if you do re-run puppet
 # on master omitting an explicit version may cause Jenkins to update before you have a chance
 # to review the changelog.
-#jenkins::version: '2.89.2'
+jenkins::version: '2.89.4'
 jenkins::slave::executors: 1
 jenkins::slave::install_java: false
 jenkins::slave::labels: agent_on_master


### PR DESCRIPTION
See https://github.com/ros-infrastructure/buildfarm_deployment/issues/193 for details.

New buildfarm deployments should use a known good Jenkins configuration until the changes in 2.107.1 can be assessed and addressed.