### PR TITLE
Move ssh_host_key config to common.

### DIFF
--- a/hiera/hieradata/buildfarm_role/agent.yaml
+++ b/hiera/hieradata/buildfarm_role/agent.yaml
@@ -3,15 +3,6 @@ jenkins::slave::labels: buildagent
 jenkins::slave::slave_mode: exclusive
 jenkins::slave::slave_name: agent
 
-# Known hosts to add to the agent user.
-# Necessary to avoid build failures requiring interactive approval of a new
-# host.
-# You should definitely add the host key for your `repo` machine and any
-# other machines you will connect to during builds: a documentation host
-# for example.
-ssh_host_keys:
-  repo: repo ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA+bpD1Hf9LB+VFN6V6xdRsTi05gPHd0l7LhWbDZpAQM
-
 # Enable squid reverse proxy to save bandwidth redownloading packages.
 run_squid: true
 squid-in-a-can::max_cache_size: 50000

--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -23,6 +23,17 @@ ssh_keys:
         user: root
 
 
+# Known hosts to add to the jenkins-agent user.
+# Necessary to avoid build failures requiring interactive approval of a new
+# host.
+# You should definitely add the host key for your `repo` machine and any
+# other machines you will connect to during builds.
+# Assuming you can access your repo host via ssh from your dev workstation, the command:
+#     ssh repo -T cat /etc/ssh/ssh_host_ed25519_key.pub
+# will print your ed25519 host key which you can paste below
+ssh_host_keys:
+  repo: repo ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA+bpD1Hf9LB+VFN6V6xdRsTi05gPHd0l7LhWbDZpAQM
+
 # if `autoreconfigure` is true this will set a cron task to re-run puppet periodically.
 # Do not autoreconfigure your master machine during normal running, doing so will overwrite
 # any configuration changes made since provisioning.


### PR DESCRIPTION
The host key is required for all machines running jenkins agent
processes which includes machines with the master and repo deployment
roles.

Additional explantion of the key purpose provides an example of how to
retrieve the host key for your repo host.