### PR TITLE
Use current stable docker version.

### DIFF
--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -53,7 +53,7 @@ docker::manage_kernel: false
 # The values below should not be changed.
 docker::package_name: docker-ce
 docker::package_source_location: https://download.docker.com/linux/ubuntu
-docker::package_source_key: https://download.docker.com/linux/ubuntu/gpg
+docker::package_key_source: https://download.docker.com/linux/ubuntu/gpg
 docker::package_key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 docker::package_release: xenial
 docker::package_repos: stable

--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -49,6 +49,16 @@ autoreconfigure::command: 'bash -c "cd /root/buildfarm_deployment_config && git 
 # https://github.com/puppetlabs/puppetlabs-docker/issues/38
 docker::manage_kernel: false
 
+# Unless you have explicit needs with the docker version
+# The values below should not be changed.
+docker::package_name: docker-ce
+docker::package_source_location: https://download.docker.com/linux/ubuntu
+docker::package_source_key: https://download.docker.com/linux/ubuntu/gpg
+docker::package_key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+docker::package_release: xenial
+docker::package_repos: stable
+docker::service_overrides_template: agent_files/docker-service-overrides.conf.erb
+
 # Classes to be pulled in via hiera_include classes.
 #classes:
     # Enables the New Relic sysmon daemon.


### PR DESCRIPTION
Docker has changed their repository structure since this package fell out of maintenance. Updated packages do not support puppet 3.8 so we are updating the upstreams by hand.

Our docker module also adds some service overrides which are no longer desireable as they cause the docker daemon to hang indefinitely on startup.
In order to remove the overrides we supply our own override template with no actual content.

While I cannot say for certain that this upgrade would fix https://github.com/ros-infrastructure/buildfarm_deployment/issues/198 I have not been able to reproduce it at all with Docker 18.03 or 18.04.

@j-rivero tagging you for review so we can improve our cross-team knowledge. Since you've got fresh eyes on the project I'm mostly checking if you think the two lines of documentation comments are sufficient indication that these values don't need to change when forking.

I've built standalone agents with Docker 18.03 but I haven't yet set it up on a testfarm or in production. My intention is to take this straight into production with kernel changes related to https://github.com/ros-infrastructure/ros_buildfarm/issues/535.