### PR TITLE
Config changes for latest Jenkins LTS

### DIFF
--- a/hiera/hieradata/buildfarm_role/master.yaml
+++ b/hiera/hieradata/buildfarm_role/master.yaml
@@ -22,7 +22,7 @@ jenkins::lts: true
 # unlikely that puppet will be run multiple times on a master host, but if you do re-run puppet
 # on master omitting an explicit version may cause Jenkins to update before you have a chance
 # to review the changelog.
-jenkins::version: '2.89.4'
+#jenkins::version: '2.138.3'
 jenkins::slave::executors: 1
 jenkins::slave::install_java: false
 jenkins::slave::labels: agent_on_master

--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -62,6 +62,17 @@ ssh_keys:
 ssh_host_keys:
   repo: repo ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA+bpD1Hf9LB+VFN6V6xdRsTi05gPHd0l7LhWbDZpAQM
 
+# Known hosts to add to the jenkins-agent user.
+# Necessary to avoid build failures requiring interactive approval of a new
+# host.
+# You should definitely add the host key for your `repo` machine and any
+# other machines you will connect to during builds.
+# Assuming you can access your repo host via ssh from your dev workstation, the command:
+#     ssh repo -T cat /etc/ssh/ssh_host_ed25519_key.pub
+# will print your ed25519 host key which you can paste below
+ssh_host_keys:
+  repo: repo ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA+bpD1Hf9LB+VFN6V6xdRsTi05gPHd0l7LhWbDZpAQM
+
 # if `autoreconfigure` is true this will set a cron task to re-run puppet periodically.
 # Do not autoreconfigure your master machine during normal running, doing so will overwrite
 # any configuration changes made since provisioning.

--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -4,6 +4,10 @@
 # If you use the GitHub authentication plugin with Jenkins you will want to set this to a GitHub username and access token.
 jenkins::slave::ui_user: 'admin'
 jenkins::slave::ui_pass: 'changeme'
+# The version of the swarm client plugin should be the same between the jenkins master and agents on all hosts.
+# Note that versions above 3.0 require use of a modified version of the docker puppet module
+jenkins::swarm_version: &jenkins_swarm_version '3.14'
+jenkins::slave::version: *jenkins_swarm_version
 
 # This should be unchanged so that the masterurl always uses the hosts entry to reach master.
 jenkins::slave::masterurl: 'http://master:8080'


### PR DESCRIPTION
The changes to support the latest LTS are minimal in the example config.

The biggest two are removing the version pin for Jenkins itself and setting the swarm client version to 3.14 (the latest as of this PR).

This pairs with https://github.com/ros-infrastructure/buildfarm_deployment/pull/207 for which a migration guide is being drafted.