### PR TITLE
Setup pre-jep-200 branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # buildfarm_deployment_config
 
+***Deprecation notice***
+
+This branch supports deployment to older Jenkins LTS hosts that haven't don't implement JEP-200.
+The canonical buildfarm: [build.ros.org](https://build.ros.org) has upgraded to a Jenkins LTS version which required many plugin updates and small potentially incompatbile changes.
+
+This branch will no longer receive improvements or bug fixes from Open Robotics but you're welcome to keep using it until you have the opportunity to upgrade.
+
+---
 This is the repository with the example configurations for the [buildfarm_deployment](https://github.com/ros-infrastructure/buildfarm_deployment) implementation.
 Please see the documentation in that repository for how to setup a buildfarm.
 

--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -67,7 +67,7 @@ ssh_host_keys:
 # any configuration changes made since provisioning.
 autoreconfigure: false
 # Pay special attention to the Git branch name that appears twice in the invocation below.
-autoreconfigure::command: 'bash -c "cd /root/buildfarm_deployment_config && git fetch origin xenialize && git reset --hard origin/xenialize && ./reconfigure.bash"'
+autoreconfigure::command: 'bash -c "cd /root/buildfarm_deployment_config && git fetch origin pre-jep-200 && git reset --hard origin/pre-jep-200 && ./reconfigure.bash"'
 
 # This docker option is being removed from the upstream puppetlabs-docker module.
 # It isn't required on Ubuntu Xenial and causes an error when deploying to AWS with the default AWS kernel.

--- a/reconfigure.bash
+++ b/reconfigure.bash
@@ -11,7 +11,7 @@ function usage {
 
 BUILDFARM_DEPLOYMENT_PATH=/root/buildfarm_deployment
 BUILDFARM_DEPLOYMENT_URL=https://github.com/ros-infrastructure/buildfarm_deployment.git
-BUILDFARM_DEPLOYMENT_BRANCH=master
+BUILDFARM_DEPLOYMENT_BRANCH=pre-jep-200
 
 script_dir="$(dirname $0)"
 


### PR DESCRIPTION
This branch should be used for buildfarm deployments which cannot currently upgrade to the latest Jenkins LTS. By fixing this branch name in place of master, future deployments will will avoid breakages when master only supports later Jenkins versions.

This is basically analogous to the deprecation of the trusty branch in #18. I even borrowed the text of that deprecation notice.