### PR TITLE
Add apt-transport-https to prerequisites.

### DIFF
--- a/install_prerequisites.bash
+++ b/install_prerequisites.bash
@@ -4,6 +4,9 @@ set -o errexit
 
 apt-get install -y puppet librarian-puppet
 
+# Needed to use the Docker upstream apt repositories.
+apt-get install apt-transport-https
+
 # install pip3 via pypi to avoid https://github.com/ros-infrastructure/buildfarm_deployment/issues/64
 apt-get install -y python3-pip
 pip3 install -U pip


### PR DESCRIPTION
If we ever update the Docker puppet module we should see if it handles this need internally so we can pull this from the prerequisites file again.

Fixes #36 