### PR TITLE
Remove duplicate stanzas.

### DIFF
--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -54,18 +54,6 @@ ssh_keys:
     #    type: REPLACE_WITH_YOUR_ADMIN_SSH_KEY_TYPE
     #   user: root
 
-
-# Known hosts to add to the jenkins-agent user.
-# Necessary to avoid build failures requiring interactive approval of a new
-# host.
-# You should definitely add the host key for your `repo` machine and any
-# other machines you will connect to during builds.
-# Assuming you can access your repo host via ssh from your dev workstation, the command:
-#     ssh repo -T cat /etc/ssh/ssh_host_ed25519_key.pub
-# will print your ed25519 host key which you can paste below
-ssh_host_keys:
-  repo: repo ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA+bpD1Hf9LB+VFN6V6xdRsTi05gPHd0l7LhWbDZpAQM
-
 # Known hosts to add to the jenkins-agent user.
 # Necessary to avoid build failures requiring interactive approval of a new
 # host.


### PR DESCRIPTION
This configuration stanza was duplicated unintentionally and probably
causes deployment issues beyond confusion when the values are updated by
hand.