### PR TITLE
Add `trusted_node_data = true` to puppet config during reconfigure.

### DIFF
--- a/reconfigure.bash
+++ b/reconfigure.bash
@@ -25,10 +25,10 @@ fi
 
 # Confirm that node-specific facts are usable.
 if ! grep -q '^trusted_node_data ?= ?true' /etc/puppet/puppet.conf; then
-  awk -f- > /tmp/puppet.conf /etc/puppet/puppet.conf <<-'AWK'
-/^\[main\]$/ { print $0; print 'trusted_node_data=true'; }
+  awk -f- > /tmp/puppet.conf /etc/puppet/puppet.conf <<'AWK'
+/^\[main\]$/ { print $0; print "trusted_node_data=true"; }
 !/^\[main\]$/ { print $0; }
-  AWK
+AWK
   mv /etc/puppet/puppet.conf /etc/puppet/puppet.conf.$(date -I)
   mv /tmp/puppet.conf /etc/puppet/puppet.conf
 fi

--- a/reconfigure.bash
+++ b/reconfigure.bash
@@ -23,6 +23,16 @@ elif [[ $# -eq 0 ]] && [[ ! -f "${script_dir}/role" ]]; then
   usage
 fi
 
+# Confirm that node-specific facts are usable.
+if ! grep -q '^trusted_node_data ?= ?true' /etc/puppet/puppet.conf; then
+  awk -f- > /tmp/puppet.conf /etc/puppet/puppet.conf <<-'AWK'
+/^\[main\]$/ { print $0; print 'trusted_node_data=true'; }
+!/^\[main\]$/ { print $0; }
+  AWK
+  mv /etc/puppet/puppet.conf /etc/puppet/puppet.conf.$(date -I)
+  mv /tmp/puppet.conf /etc/puppet/puppet.conf
+fi
+
 
 # Check if a role file exists for the current machine.
 if [ -f "${script_dir}/role" ]; then


### PR DESCRIPTION
https://github.com/ros-infrastructure/buildfarm_deployment/pull/211 adds some puppet that uses facts from local node data. This configuration directive is required to do so. 