### PR TITLE
Fix role conditional in reconfigure.bash

### DIFF
--- a/reconfigure.bash
+++ b/reconfigure.bash
@@ -27,7 +27,7 @@ fi
 # Check if a role file exists for the current machine.
 if [ -f "${script_dir}/role" ]; then
   buildfarm_role=$(cat "${script_dir}/role")
-  if [ $1 != $buildfarm_role ]; then
+  if [ "$1" != "" ] && [ "$1" != "$buildfarm_role" ]; then
     echo "ERROR: this machine was previously provisioned as ${buildfarm_role}"
     echo "  To change role to $1 please delete the 'role' file and rerun this command."
     exit 1


### PR DESCRIPTION
Right now, if you run `reconfigure.bash` without supplying a role when the `role` file exists in the repository root, the script will use the role specified in the file and display the following non-fatal syntax error: `./reconfigure.bash: line 30: [: !=: unary operator expected`

This change keeps the current behavior but fixes the conditional.