### PR TITLE
Clarify use of GitHub Authentication plugin credentials

### DIFF
--- a/hiera/hieradata/common.yaml
+++ b/hiera/hieradata/common.yaml
@@ -1,7 +1,9 @@
 # Jenkins username and password the agents should use to authenticate with the client.
 # Both master and repo machines have specific agents: agent_on_master and building_repostory respectively
 # That make use of this configuration as well.
-# If you use the GitHub authentication plugin with Jenkins you will want to set this to a GitHub username and access token.
+# If you use the [GitHub authentication plugin](https://plugins.jenkins.io/github-oauth/) as the authentication
+# provider for Jenkins you will want to register it as a [GitHub application](https://github.com/settings/applications/new)
+# and set this to a GitHub username and access token.
 jenkins::slave::ui_user: 'admin'
 jenkins::slave::ui_pass: 'changeme'
 # The version of the swarm client plugin should be the same between the jenkins master and agents on all hosts.


### PR DESCRIPTION
This should hopefully prevent confusion
```
2020-02-07 14:57:19 +0100 Puppet (err): java -jar /usr/share/jenkins/jenkins-cli.jar -s http://127.0.0.1:8080 -auth myci:REDACTED groovy = < /tmp/configure
_git_user.groovy returned 255 instead of one of [0]
```